### PR TITLE
Etag support

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,19 +9,25 @@ Using Django and raw js to begin with, server side will be provided by individua
 
 ### Django template tag
 1. Include the `field_update` app in your django settings INSTALLED_APPS
-2. Identify the url you wish to POST updates to, the url should uniquely identify the object
 4. Ensure you have csrf_token cookie present by using `ensure_csrf_cookie` decorator on your view
+2. Identify the submit view and url you wish to send updates to
 3. load the field updater template tags library in the template you wish to place the updater 
 
 `{% load field_updater_tags %}`
 
-4. Use the field updater template tag passing the initial value to display, the url to POST to, and the attribute name and initial value as a key value pair
+4. Use the field updater template tag passing the url to request to, and the attribute name and initial value as a key value pair
 
-`{% field_updater submit_url=SUBMIT_URL allow_delete=True attribute_name=ATTRIBUTE_VALUE %}`
+{% url 'submit_url_name' some_arg=some_value as submit_url %}
 
-The initial value will be displayed, on clicking the display an update text input will show, edit the value and click the tick, and a POST request will be submitted to the SUBMIT_URL with formencoded data of ATTRIBUTE_NAME=NEW_VALUE which can be read through the django request.POST QueryDict 
-If you specify `allow_delete=True` the componenet will allow the user to click to send a DELETE request to the server, when the current value is not `null`
+`{% field_updater submit_url=submit_url attribute_name=attribute_value %}`
+`{% field_updater submit_url=submit_url attribute_name=attribute_value  allow_delete=True %}`
 
+The initial value will be displayed, on clicking the display an update text input will show, edit the value and click the tick, and a POST request will be submitted to `submit_url with formencoded data of `attribute_name=attribute_value`
+
+If you specify `allow_delete=True` it will allow the user to click to send a DELETE request when the current value is not `null`
+
+If you specify `etag=some_etag_value` it will send that value as an `If-Match` header
+If you specify `last_modified=some_http_date` it will send that value as 'If-Unmodified-Since' header
 
 ## Possible future
 
@@ -31,5 +37,5 @@ Send more key=value pairs through to the tag for update together
 Maybe allowing the js component to take a form definition for rendering
 ### Validation handling
 Adding simple configurable validation
-### Riot componenet
-Adding a riot componenet to use where django is not present
+### Riot component
+Adding a riot component to use where django is not present

--- a/static/js/ajaxUpdate.js
+++ b/static/js/ajaxUpdate.js
@@ -9,7 +9,7 @@ export default class AjaxUpdater {
      * options:
      * url           - the url to communicate with ( will update to Location header value )
      * etag          - the value of the If-Match header to send, use false to disable
-     * lastModified  - the value of the If-Match header to send, use false to disable
+     * lastModified  - the value of the If-Unmofified-Since header to send, use false to disable
 
      */
     constructor(options) {

--- a/static/js/ajaxUpdate.js
+++ b/static/js/ajaxUpdate.js
@@ -7,11 +7,11 @@ export default class AjaxUpdater {
      * returns a promise that will resolve if the action is successful, and reject if not
      *
      * options:
-     * url           - the url to communicate with ( will update to Location header value )
-     * etag          - the value of the If-Match header to send, use false to disable
-     * lastModified  - the value of the If-Unmofified-Since header to send, use false to disable
-
+     * url                - the url to communicate with ( will update to Location header value )
+     * ifMatch            - the value of the If-Match header to send, use false to disable
+     * ifUnmodifiedSince  - the value of the If-Unmodified-Since header to send, use false to disable
      */
+
     constructor(options) {
         this.options = Object.assign({}, options);
     }   
@@ -41,11 +41,11 @@ export default class AjaxUpdater {
             let headers = {
                 'X-CSRFToken': getCsrfToken(),
             }
-            if(this.options.etag) {
-                headers['If-Match'] = `"${this.options.etag}"`;
+            if(this.options.ifMatch) {
+                headers['If-Match'] = `"${this.options.ifMatch}"`;
             }
-            if(this.options.lastModified) {
-                headers['If-Unmodified-Since'] = this.options.lastModified;
+            if(this.options.ifUnmodifiedSince) {
+                headers['If-Unmodified-Since'] = this.options.ifUnmodifiedSince;
             }
             fetch(
                 this.options.url,
@@ -66,11 +66,11 @@ export default class AjaxUpdater {
     }
 
     updateFetchOptions(headers) {
-        if (headers.has('ETag') && this.options.etag !== false) {
-            this.options.etag = headers.get('ETag');
+        if (headers.has('ETag') && this.options.ifMatch !== false) {
+            this.options.ifMatch = headers.get('ETag');
         }
-        if (headers.has('Last-Modified') && this.options.lastModified !== false) {
-            this.options.lastModified = headers.get('Last-Modified');
+        if (headers.has('Last-Modified') && this.options.ifUnmodifiedSince !== false) {
+            this.options.ifUnmodifiedSince = headers.get('Last-Modified');
         }
         if (headers.has('Location')) {
             this.options.url = headers.get('Location');

--- a/static/js/ajaxUpdate.js
+++ b/static/js/ajaxUpdate.js
@@ -1,37 +1,79 @@
-export async function ajaxDelete(options) {
-    const fetchInit = {
-        method: 'DELETE',
-    };
-    return ajax(options.submit_url, fetchInit);    
-}
-export async function ajaxUpdate(data, options) {
-    const fetchInit = {
-        method: 'POST',
-        body: new FormData(),
-    };
-    Object.keys(data).forEach((key) => {
-        fetchInit.body.set(key, data[key]);
-    });
-    return ajax(options.submit_url, fetchInit);    
-}
+export default class AjaxUpdater {
+    /* AjaxUpdater - class to provide ajax update methods
+     *
+     * updateOrCreate - sends a POST request to options.url with form encoded data
+     * remove - sends a DELETE request to options.url
+     *
+     * returns a promise that will resolve if the action is successful, and reject if not
+     *
+     * options:
+     * url           - the url to communicate with ( will update to Location header value )
+     * etag          - the value of the If-Match header to send, use false to disable
+     * lastModified  - the value of the If-Match header to send, use false to disable
 
-async function ajax(url, fetchInit) {
-    let {default:getCsrfToken} = await import('./getCsrfToken.js');
-    // make our request to udpate the value
-    return new Promise((resolve, reject) => {
-        
-        fetch(
-            url,
-            Object.assign({ headers: {'X-CSRFToken': getCsrfToken()}}, fetchInit)
-        ).then(function(response) {
-            // function that will run on promise resolve;
-            if(response.ok) {
-                resolve(response.status, response);
-            } else {
-                reject(response.statusText, response.status, response)
-            }
-        }).catch(function(err) {
-            reject(err.message, err)
+     */
+    constructor(options) {
+        this.options = Object.assign({}, options);
+    }   
+
+    async remove() {
+        const fetchInit = {
+            method: 'DELETE',
+        };
+        return this.ajax(fetchInit);    
+    }
+
+    async updateOrCreate(data) {
+        const fetchInit = {
+            method: 'POST',
+            body: new FormData(),
+        };
+        Object.keys(data).forEach((key) => {
+            fetchInit.body.set(key, data[key]);
         });
-    });
+        return this.ajax(fetchInit);
+    }
+
+    async ajax(fetchInit) {
+        const self = this;
+        return new Promise(async (resolve, reject) => {
+            let { default:getCsrfToken } = await import('./getCsrfToken.js');
+            let headers = {
+                'X-CSRFToken': getCsrfToken(),
+            }
+            if(this.options.etag) {
+                headers['If-Match'] = `"${this.options.etag}"`;
+            }
+            if(this.options.lastModified) {
+                headers['If-Unmodified-Since'] = this.options.lastModified;
+            }
+            fetch(
+                this.options.url,
+                Object.assign({headers}, fetchInit)
+            ).then(function(response) {
+                // update the internal options
+                self.updateFetchOptions(response.headers);
+
+                if(response.ok) {
+                    resolve(response.status, response);
+                } else {
+                    reject(response.statusText, response.status, response)
+                }
+            }).catch(function(err) {
+                reject(err.message, err)
+            });
+        });
+    }
+
+    updateFetchOptions(headers) {
+        if (headers.has('ETag') && this.options.etag !== false) {
+            this.options.etag = headers.get('ETag');
+        }
+        if (headers.has('Last-Modified') && this.options.lastModified !== false) {
+            this.options.lastModified = headers.get('Last-Modified');
+        }
+        if (headers.has('Location')) {
+            this.options.url = headers.get('Location');
+        }
+    }
 }

--- a/static/js/fieldUpdater.js
+++ b/static/js/fieldUpdater.js
@@ -1,4 +1,4 @@
-export default function initialise(options) {
+export default async function initialise(options) {
     // gets a reference to the containing element for the component
     const containerElement = document.getElementById(options.prefix + '-' + options.instance_id);
 
@@ -12,8 +12,14 @@ export default function initialise(options) {
     const loaderElement = containerElement.querySelector('.' + options.prefix + '-loader');
     const errorElement = containerElement.querySelector('.' + options.prefix + '-error');
 
+    const { default: StorageHandler } = await import("./ajaxUpdate.js");
 
     let current_value = options.attribute_value;
+    const storage = new StorageHandler({
+        url: options.submit_url,
+        etag: options.etag,
+        lastModified: options.last_modified,
+    });
 
     // set the display back to default
     function updateDisplay() {
@@ -41,7 +47,6 @@ export default function initialise(options) {
         displayElement.hidden = false;
     };
     
-
     // handler to encapsulate an async submission action ( update or delete )
     function submit(action) {
         inputsElement.hidden = true;
@@ -61,30 +66,29 @@ export default function initialise(options) {
 
     // what happens when the delete button is clicked
     deleteElement.onclick = async function(e) {
-        let { ajaxDelete } = await import("./ajaxUpdate.js");
         submit(() => { 
-            return ajaxDelete(options).then(() => {
+            return storage.remove().then(() => {
                 current_value = null;
             }); 
         });
     };
 
     // what happens when the update button is clicked
-    submitElement.onclick = () => create_or_update(inputElement.value);
+    submitElement.onclick = () => updateOrCreate(inputElement.value);
 
     // waht happens when a key is hit in the input
     inputElement.onkeyup = function(e) {
-        if (e.key === 'Enter') create_or_update(inputElement.value);
+        if (e.key === 'Enter') updateOrCreate(inputElement.value);
     }
 
-    async function create_or_update(newValue) {
+    async function updateOrCreate(newValue) {
         let { ajaxUpdate } = await import("./ajaxUpdate.js");
 
         const data = {};
         data[options.attribute_name] = newValue;
 
         submit(() => { 
-            return ajaxUpdate(data, options).then(() => {
+            return storage.updateOrCreate(data).then(() => {
                 current_value = newValue;
             }); 
         });

--- a/static/js/fieldUpdater.js
+++ b/static/js/fieldUpdater.js
@@ -17,8 +17,8 @@ export default async function initialise(options) {
     let current_value = options.attribute_value;
     const storage = new StorageHandler({
         url: options.submit_url,
-        etag: options.etag,
-        lastModified: options.last_modified,
+        ifUnmodifiedSince: options.if_unmodified_since,
+        ifMatch: options.if_match,
     });
 
     // set the display back to default

--- a/templates/field_updater/field_updater.html
+++ b/templates/field_updater/field_updater.html
@@ -13,7 +13,7 @@ TODO: consider other input types, textarea etc...
 {% endcomment %}
 <div class="{{ options.prefix }}" id="{{ options.prefix }}-{{ options.instance_id }}">
     <a class="{{ options.prefix }}-display"></a>
-    <button type="button" class="{{ options.prefix }}-delete">
+    <button type="button" class="{{ options.prefix }}-delete" hidden>
         &#9988;
     </button>
     <span class="{{ options.prefix }}-error" hidden></span>

--- a/templatetags/field_updater_tags.py
+++ b/templatetags/field_updater_tags.py
@@ -6,8 +6,10 @@ register = template.Library()
 
 @register.inclusion_tag('field_updater/field_updater.html')
 def field_updater(
-    submit_url, # url that the ajax will POST the create to
+    submit_url,              # url that the ajax will POST the create to
     prefix='field-updater',  # prefix used for id and class scoping,
+    etag=False,              # If-Match header will be sent with this value, unless False
+    last_modified=False,     # If-Unmodified-Since header will be sent with this value unless False
     **kwargs):
     ''' Renders a value, on click it will render a form, on submit update that value by AJAX '''
 
@@ -28,6 +30,8 @@ def field_updater(
             'attribute_value': attribute_value,
             'allow_delete': allow_delete,
             'submit_url': submit_url,
+            'etag': etag,
+            'last_modified': last_modified,
             'prefix': prefix,
         },
     }

--- a/templatetags/field_updater_tags.py
+++ b/templatetags/field_updater_tags.py
@@ -6,10 +6,10 @@ register = template.Library()
 
 @register.inclusion_tag('field_updater/field_updater.html')
 def field_updater(
-    submit_url,              # url that the ajax will POST the create to
-    prefix='field-updater',  # prefix used for id and class scoping,
-    etag=False,              # If-Match header will be sent with this value, unless False
-    last_modified=False,     # If-Unmodified-Since header will be sent with this value unless False
+    submit_url,                   # url that the ajax will POST the create to
+    prefix='field-updater',       # prefix used for id and class scoping,
+    if_match=False,               # If-Match header will be sent with this value, unless False
+    if_unmodified_since=False,    # If-Unmodified-Since header will be sent with this value unless False
     **kwargs):
     ''' Renders a value, on click it will render a form, on submit update that value by AJAX '''
 
@@ -30,8 +30,8 @@ def field_updater(
             'attribute_value': attribute_value,
             'allow_delete': allow_delete,
             'submit_url': submit_url,
-            'etag': etag,
-            'last_modified': last_modified,
+            'if_match': if_match,
+            'if_unmodified_since': if_unmodified_since,
             'prefix': prefix,
         },
     }


### PR DESCRIPTION
fixes #8 

- If you specify `if_match=some_etag_value` it will send that value as an `If-Match` header
- If you specify `if_unmodified_since=some_http_date` it will send that value as 'If-Unmodified-Since' header

Moves AjaxUpdate into an instantiated class that can track etag/lastmod values, and also obey the location header returned by the api.

Not quite worked out what the initial etag should be in the case where an object does not exist, but that is probably a server side concern