### PR TITLE
Use content-type application/x-www-form-urlencoded

### DIFF
--- a/static/js/ajaxUpdate.js
+++ b/static/js/ajaxUpdate.js
@@ -22,7 +22,12 @@ async function ajax(url, fetchInit) {
         
         fetch(
             url,
-            Object.assign({ headers: {'X-CSRFToken': getCsrfToken()}}, fetchInit)
+            Object.assign({
+                headers: {
+                    'X-CSRFToken': getCsrfToken(),
+                    'Content-Type': 'application/x-www-form-urlencoded',
+                }
+            }, fetchInit)
         ).then(function(response) {
             // function that will run on promise resolve;
             if(response.ok) {

--- a/static/js/ajaxUpdate.js
+++ b/static/js/ajaxUpdate.js
@@ -7,11 +7,8 @@ export async function ajaxDelete(options) {
 export async function ajaxUpdate(data, options) {
     const fetchInit = {
         method: 'POST',
-        body: new FormData(),
+        body: BODY_ENCODE_FUNCTIONS[options.bodyEncode](data),
     };
-    Object.keys(data).forEach((key) => {
-        fetchInit.body.set(key, data[key]);
-    });
     return ajax(options.submit_url, fetchInit);    
 }
 
@@ -25,7 +22,6 @@ async function ajax(url, fetchInit) {
             Object.assign({
                 headers: {
                     'X-CSRFToken': getCsrfToken(),
-                    'Content-Type': 'application/x-www-form-urlencoded',
                 }
             }, fetchInit)
         ).then(function(response) {
@@ -39,4 +35,21 @@ async function ajax(url, fetchInit) {
             reject(err.message, err)
         });
     });
+}
+
+function urlEncode(data) {
+   return new URLSearchParams(data);
+}
+
+function formEncode(data) {
+    let formData = new FormData();
+    Object.keys(data).forEach((key) => {
+        formData.set(key, data[key]);
+    });
+    return formData;
+}
+
+const BODY_ENCODE_FUNCTIONS = {
+    'urlencoded': urlEncode,
+    'form-data': formEncode,
 }

--- a/templatetags/field_updater_tags.py
+++ b/templatetags/field_updater_tags.py
@@ -8,6 +8,7 @@ register = template.Library()
 def field_updater(
     submit_url, # url that the ajax will POST the create to
     prefix='field-updater',  # prefix used for id and class scoping,
+    body_encode='form-data',  # the content encoding for POST bodies
     **kwargs):
     ''' Renders a value, on click it will render a form, on submit update that value by AJAX '''
 
@@ -19,6 +20,9 @@ def field_updater(
     except KeyError:
         raise AttributeError('This tag requires a key value attribute describing the field to be updated')
 
+    if body_encode not in ['urlencoded', 'form-data']:
+        raise AttributeError('The body_encode must be urlencoded or form-data')
+
     # random uuid to scope the DOM elements
     instance_id = uuid.uuid4()
     return {
@@ -28,6 +32,7 @@ def field_updater(
             'attribute_value': attribute_value,
             'allow_delete': allow_delete,
             'submit_url': submit_url,
+            'bodyEncode': body_encode,
             'prefix': prefix,
         },
     }


### PR DESCRIPTION
This sends `Content-Type: application/x-www-form-urlencoded;charset=UTF-8` when body_encode is set to urlencoded.

It turns out fetch sets the content type automatically if you use a FormData body, or an URLSearchParams, which is nice :)

default is to use `multipart/form-data` I could be persuaded to reverse that