### PR TITLE
Allow configurable empty display - enables translations

### DIFF
--- a/static/js/fieldUpdater.js
+++ b/static/js/fieldUpdater.js
@@ -18,7 +18,7 @@ export default function initialise(options) {
     // set the display back to default
     function updateDisplay() {
         deleteElement.hidden = !options.allow_delete || current_value === null;
-        displayElement.innerHTML = current_value || 'empty';
+        displayElement.innerHTML = current_value || options.emptyDisplay;
     };
     updateDisplay();
 

--- a/templates/field_updater/example.html
+++ b/templates/field_updater/example.html
@@ -2,6 +2,6 @@
 <html>
     <body>
         {% url 'example_submit' name="peter" as submit_url %}
-        {% field_updater override=None submit_url=submit_url|add:"?querykey="|add:"queryval" allow_delete=True %}
+        {% field_updater override='yo' submit_url=submit_url|add:"?querykey="|add:"queryval" allow_delete=True empty_display='NO VALUE'%}
     </body>
 </html>

--- a/templatetags/field_updater_tags.py
+++ b/templatetags/field_updater_tags.py
@@ -1,6 +1,5 @@
 import uuid
 from django import template
-from django.urls import reverse
 
 register = template.Library()
 
@@ -9,6 +8,7 @@ def field_updater(
     submit_url, # url that the ajax will POST the create to
     prefix='field-updater',  # prefix used for id and class scoping,
     body_encode='form-data',  # the content encoding for POST bodies
+    empty_display='empty',              # the text displayed when the value is an empty string or none
     headers_accept='application/json',
     **kwargs):
     ''' Renders a value, on click it will render a form, on submit update that value by AJAX '''
@@ -35,6 +35,7 @@ def field_updater(
             'submit_url': submit_url,
             'bodyEncode': body_encode,
             'prefix': prefix,
+            'emptyDisplay': empty_display,
             'headersAccept': headers_accept,
         },
     }


### PR DESCRIPTION
fixes #15 

you will have to pass the translation down through the template tag
```
{% trans 'empty' as empty_translation %}
{% field_updater override='yo' submit_url=submit_url|add:"?querykey="|add:"queryval" allow_delete=True empty_display=empty_translation %}
```
