### PR TITLE
Allow input attributes control

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,24 +9,60 @@ Using Django and raw js to begin with, server side will be provided by individua
 
 ### Django template tag
 1. Include the `field_update` app in your django settings INSTALLED_APPS
-4. Ensure you have csrf_token cookie present by using `ensure_csrf_cookie` decorator on your view
-2. Identify the submit view and url you wish to send updates to
-3. load the field updater template tags library in the template you wish to place the updater 
+2. Ensure you have csrf_token cookie present by using `ensure_csrf_cookie` decorator on your view
+3. Identify the submit view and url you wish to send updates to
+
+if your api returns a Location header the componenet will subequently use that as the submit url
+
+4. load the field updater template tags library in the template you wish to place the updater 
 
 `{% load field_updater_tags %}`
 
-4. Use the field updater template tag passing the url to request to, and the attribute name and initial value as a key value pair
+5. Use the field updater template tag passing the url to request to, and the attribute name and initial value as a key value pair
 
-{% url 'submit_url_name' some_arg=some_value as submit_url %}
-
+`{% url 'submit_url_name' some_arg=some_value as submit_url %}`
 `{% field_updater submit_url=submit_url attribute_name=attribute_value %}`
-`{% field_updater submit_url=submit_url attribute_name=attribute_value allow_delete=True %}`
 
-The initial value will be displayed, on clicking the display an update text input will show, edit the value and click the tick, and a POST request will be submitted to `submit_url with formencoded data of `attribute_name=attribute_value`
+#### Optionally
+6. Pass instance specific options such as ifMatch or ifUnmodifiedSince to help prevent lost update issues
 
-If you specify `allow_delete=True` it will allow the user to click to send a DELETE request when the current value is not `null`
-If you specify `if_match=some_etag_value` it will send that value as an `If-Match` header
-If you specify `if_unmodified_since=some_http_date` it will send that value as `If-Unmodified-Since` header
+The component will start sending ifMatch if your enpoint returns an ETag header, unless you pass ifMatch=False
+
+The component will start sending IfUnmodifiedSince headers if you endpoint returns a Last-Modified header, unless you pass IfUnmodifiedSince=False
+
+`{% field_updater submit_url=submit_url attribute_name=attribute_value ifMatch='an_etag' %}`
+
+`{% field_updater submit_url=submit_url attribute_name=attribute_value ifUnmodifiedSince=last_modified %}`
+
+7. Provide an options dictionary, the defaults are as follows and can all be overridden
+
+```
+    default_options = {
+        'prefix': 'field-updater',      # prefix used for id and class scoping,
+        'allowDelete': False,           # delete will be allowed only if true
+        'bodyEncode': 'form-data',      # the content encoding for POST bodies ( form-data and urlencoded supported )
+        'emptyDisplay': 'empty',        # the text displayed when the value is an empty string or none
+        'headers': {},                  # the set of headers sent with ajax requests
+        'inputAttributes': {            # input attributes
+            'type': 'text',             # only text and number supported
+        },
+    }
+```
+
+example of overriding to set number input type and an Accept header
+```
+# in your view
+    def get_context_data(self, **kwargs):
+        context = super().get_context_data(**kwargs)
+
+        context['updater_options'] = dict(
+            inputAttributes=dict(type='number'),
+            headers=dict(yourHeader='yourHeaderValue'),
+        )
+        return context
+# in your template
+        {% field_updater submit_url=submit_url key='headers' options=updater_options %}
+```
 
 ## Possible future
 

--- a/README.md
+++ b/README.md
@@ -24,15 +24,15 @@ if your api returns a Location header the componenet will subequently use that a
 `{% field_updater submit_url=submit_url attribute_name=attribute_value %}`
 
 #### Optionally
-6. Pass instance specific options such as ifMatch or ifUnmodifiedSince to help prevent lost update issues
+6. Pass instance specific options such as if_match or if_unmodified_since to help prevent lost update issues
 
-The component will start sending ifMatch if your enpoint returns an ETag header, unless you pass ifMatch=False
+This will send If-Match or If-Unmodified-Since header with the value passed, enabling the endpoint to return status 412
+The component will start sending If-Match if your endpoint returns an ETag header, unless you pass if_match=False
+The component will start sending If-Unmodified-Since headers if you endpoint returns a Last-Modified header, unless you pass if_unmodified_since=False
 
-The component will start sending IfUnmodifiedSince headers if you endpoint returns a Last-Modified header, unless you pass IfUnmodifiedSince=False
+`{% field_updater submit_url=submit_url attribute_name=attribute_value if_match='an_etag' %}`
 
-`{% field_updater submit_url=submit_url attribute_name=attribute_value ifMatch='an_etag' %}`
-
-`{% field_updater submit_url=submit_url attribute_name=attribute_value ifUnmodifiedSince=last_modified %}`
+`{% field_updater submit_url=submit_url attribute_name=attribute_value if_unmodified_since=last_modified %}`
 
 7. Provide an options dictionary, the defaults are as follows and can all be overridden
 

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ if your api returns a Location header the componenet will subequently use that a
 
 This will send If-Match or If-Unmodified-Since header with the value passed, enabling the endpoint to return status 412
 The component will start sending If-Match if your endpoint returns an ETag header, unless you pass if_match=False
-The component will start sending If-Unmodified-Since headers if you endpoint returns a Last-Modified header, unless you pass if_unmodified_since=False
+The component will start sending If-Unmodified-Since headers if your endpoint returns a Last-Modified header, unless you pass if_unmodified_since=False
 
 `{% field_updater submit_url=submit_url attribute_name=attribute_value if_match='an_etag' %}`
 

--- a/static/js/fieldUpdater.js
+++ b/static/js/fieldUpdater.js
@@ -1,41 +1,39 @@
-export default async function initialise(options) {
+export default async function initialise(config) {
     // gets a reference to the containing element for the component
-    const containerElement = document.getElementById(options.prefix + '-' + options.instance_id);
+    const containerElement = document.getElementById(config.options.prefix + '-' + config.instanceId);
 
     // gets references to internal elements
-    const displayElement = containerElement.querySelector('.' + options.prefix + '-display');
-    const inputsElement = containerElement.querySelector('.' + options.prefix + '-inputs');
-    const inputElement = containerElement.querySelector('.' + options.prefix + '-input');
-    const submitElement = containerElement.querySelector('.' + options.prefix + '-submit');
-    const cancelElement = containerElement.querySelector('.' + options.prefix + '-cancel');
-    const deleteElement = containerElement.querySelector('.' + options.prefix + '-delete');
-    const loaderElement = containerElement.querySelector('.' + options.prefix + '-loader');
-    const errorElement = containerElement.querySelector('.' + options.prefix + '-error');
+    const displayElement = containerElement.querySelector('.' + config.options.prefix + '-display');
+    const inputsElement = containerElement.querySelector('.' + config.options.prefix + '-inputs');
+    const inputElement = containerElement.querySelector('.' + config.options.prefix + '-input');
+    const submitElement = containerElement.querySelector('.' + config.options.prefix + '-submit');
+    const cancelElement = containerElement.querySelector('.' + config.options.prefix + '-cancel');
+    const deleteElement = containerElement.querySelector('.' + config.options.prefix + '-delete');
+    const loaderElement = containerElement.querySelector('.' + config.options.prefix + '-loader');
+    const errorElement = containerElement.querySelector('.' + config.options.prefix + '-error');
 
     const { default: StorageHandler } = await import("./ajaxUpdate.js");
 
-    let current_value = options.attribute_value;
+    let currentValue = config.attributeValue;
     const storage = new StorageHandler({
-        url: options.submit_url,
-        ifUnmodifiedSince: options.if_unmodified_since,
-        ifMatch: options.if_match,
-        bodyEncode: options.bodyEncode,
-        customHeaders: {
-            'Accept': options.headersAccept,
-        },
+        url: config.submitUrl,
+        ifUnmodifiedSince: config.ifUnmodifiedSince,
+        ifMatch: config.ifMatch,
+        bodyEncode: config.options.bodyEncode,
+        customHeaders: config.options.headers,
     });
 
     // set the display back to default
     function updateDisplay() {
-        deleteElement.hidden = !options.allow_delete || current_value === null;
-        displayElement.innerHTML = current_value || options.emptyDisplay;
+        deleteElement.hidden = !config.options.allowDelete || currentValue === null;
+        displayElement.innerHTML = currentValue || config.options.emptyDisplay;
     };
     updateDisplay();
 
     // what happens when the default value display is clicked
     displayElement.onclick = function(e) {
         // show and update the input elements
-        inputElement.value = current_value;
+        inputElement.value = currentValue;
         inputsElement.hidden = false;
         // hide the display elements
         displayElement.hidden = true;
@@ -72,7 +70,7 @@ export default async function initialise(options) {
     deleteElement.onclick = async function(e) {
         submit(() => { 
             return storage.remove().then(() => {
-                current_value = null;
+                currentValue = null;
             }); 
         });
     };
@@ -89,11 +87,11 @@ export default async function initialise(options) {
         let { ajaxUpdate } = await import("./ajaxUpdate.js");
 
         const data = {};
-        data[options.attribute_name] = newValue;
+        data[config.attributeName] = newValue;
 
         submit(() => { 
             return storage.updateOrCreate(data).then(() => {
-                current_value = newValue;
+                currentValue = newValue;
             }); 
         });
     }

--- a/templates/field_updater/example.html
+++ b/templates/field_updater/example.html
@@ -1,7 +1,66 @@
 {% load field_updater_tags %}
 <html>
     <body>
-        {% url 'example_submit' name="peter" as submit_url %}
-        {% field_updater override='yo' submit_url=submit_url|add:"?querykey="|add:"queryval" allow_delete=True empty_display='NO VALUE'%}
+        <section>
+            <h1>Field Updater Examples</h1>
+            <h2>simple use</h2>
+            <p>
+                Provide a submit url and a single key word argument<br />
+                Click the value to show an input, edit it aand submit
+                A POST request will be sent to the url with body form encoded <code>key=value</code>
+
+            </p>
+            <div class="code">
+                {% verbatim %}
+                {% url 'example_submit' as submit_url %}
+                <br />
+                {% field_updater submit_url=submit_url  key='value' %}
+                {% endverbatim %}
+            </div>
+            {% url 'example_submit' as submit_url %}
+            {% field_updater submit_url=submit_url  key='value' %}
+
+            <h2>input types</h2>
+            <p>
+                Provide an options dict containing <code>inputAttributes</code>a these attributes will be aplied to the input element displayed
+            </p>
+            <div class="code">
+                {% verbatim %}
+                {% url 'example_submit' as submit_url %}
+                <br />
+                {% field_updater submit_url=submit_url  key=42 options=updater_options_number %}
+                {% endverbatim %}
+            </div>
+            {% url 'example_submit' as submit_url %}
+            {% field_updater submit_url=submit_url key=42 options=updater_options_number %}
+
+            <h2>allow deletion</h2>
+            <p>
+                Provide an options dict containing <code>allowDelete = True</code>
+            </p>
+            <div class="code">
+                {% verbatim %}
+                {% url 'example_submit' as submit_url %}
+                <br />
+                {% field_updater submit_url=submit_url  key='deleteable' options=updater_options_delete %}
+                {% endverbatim %}
+            </div>
+            {% url 'example_submit' as submit_url %}
+            {% field_updater submit_url=submit_url key='deleteable' options=updater_options_delete %}
+
+            <h2>sending custom headers</h2>
+            <p>
+            Provide an options dict containing <code>headers={'yourHeader':'yourHeaderValue'}</code>
+            </p>
+            <div class="code">
+                {% verbatim %}
+                {% url 'example_submit' as submit_url %}
+                <br />
+                {% field_updater submit_url=submit_url  key='headers' options=updater_options_headers %}
+                {% endverbatim %}
+            </div>
+            {% url 'example_submit' as submit_url %}
+            {% field_updater submit_url=submit_url key='headers' options=updater_options_headers %}
+        </section>
     </body>
 </html>

--- a/templates/field_updater/field_updater.html
+++ b/templates/field_updater/field_updater.html
@@ -11,40 +11,42 @@ You can override the css by providing this file in your project
 TODO: try to separate out the individual components for overriding
 TODO: consider other input types, textarea etc...
 {% endcomment %}
-<div class="{{ options.prefix }}" id="{{ options.prefix }}-{{ options.instance_id }}">
-    <a class="{{ options.prefix }}-display"></a>
-    <button type="button" class="{{ options.prefix }}-delete" hidden>
+<div class="{{ updater.options.prefix }}" id="{{ updater.options.prefix }}-{{ updater.instanceId }}">
+    <a class="{{ updater.options.prefix }}-display"></a>
+    <button type="button" class="{{ updater.options.prefix }}-delete" hidden>
         &#9988;
     </button>
-    <span class="{{ options.prefix }}-error" hidden></span>
-    <div class="{{ options.prefix }}-inputs" hidden>
-        <input type="text" class="{{ options.prefix }}-input">
-        <span class="{{ options.prefix }}-clear"></span>
-        <button type="submit" class="{{ options.prefix }}-submit">
+    <span class="{{ updater.options.prefix }}-error" hidden></span>
+    <div class="{{ updater.options.prefix }}-inputs" hidden>
+        <input
+            {% for key, value in updater.options.inputAttributes.items %} {{ key }}="{{ value }}" {% endfor %}
+            class="{{ updater.options.prefix }}-input" />
+        <span class="{{ updater.options.prefix }}-clear"></span>
+        <button type="submit" class="{{ updater.options.prefix }}-submit">
             &#10003;
         </button>
-        <button type="button" class="{{ options.prefix }}-cancel">
+        <button type="button" class="{{ updater.options.prefix }}-cancel">
             &#10005;
         </button>
     </div>
     {% comment %} 
     You can override the loader gif by providing this file in your project
     {% endcomment %}
-    <img class="{{ options.prefix }}-loader" src="{% static 'img/loading.gif' %}" hidden/>
+    <img class="{{ updater.options.prefix }}-loader" src="{% static 'img/loading.gif' %}" hidden/>
 </div>
 
-{% with "json-"|addstr:options.instance_id as jsonid %}
+{% with "json-"|addstr:updater.instanceId as jsonid %}
 
-{{ options|json_script:jsonid }}
+{{ updater|json_script:jsonid }}
 <script>
     (async () => {
-        const options = JSON.parse(document.getElementById('{{jsonid}}').textContent);
+        const updaterConfig = JSON.parse(document.getElementById('{{jsonid}}').textContent);
 
         {% comment %} 
         You can override the fieldUpdate code by providing this file in your project
         {% endcomment %}
         let { default:initialise } = await import("{% static 'js/fieldUpdater.js' %}");
-        initialise(options);
+        initialise(updaterConfig);
     })()
 </script>
 

--- a/templatetags/field_updater_tags.py
+++ b/templatetags/field_updater_tags.py
@@ -6,43 +6,52 @@ register = template.Library()
 @register.inclusion_tag('field_updater/field_updater.html')
 def field_updater(
     submit_url,                         # url that the ajax will POST the create to
-    prefix='field-updater',             # prefix used for id and class scoping,
     if_match=False,                     # If-Match header will be sent with this value, unless False
     if_unmodified_since=False,          # If-Unmodified-Since header will be sent with this value unless False
-    body_encode='form-data',            # the content encoding for POST bodies
-    empty_display='empty',              # the text displayed when the value is an empty string or none
-    headers_accept='application/json',
+    options=None,               # Options for this field updater
     **kwargs):
     ''' Renders a value, on click it will render a form, on submit update that value by AJAX '''
 
-    # delete will be allowed only if requested
-    allow_delete = kwargs.pop("allow_delete", False)
     #  any extra attributes will be editable, currently we only support one
     try:
         attribute_name, attribute_value = kwargs.popitem()
     except KeyError:
         raise AttributeError('This tag requires a key value attribute describing the field to be updated')
 
-    if body_encode not in ['urlencoded', 'form-data']:
-        raise AttributeError('The body_encode must be urlencoded or form-data')
+    # default values for options to be overridden by parameter updater_options
+    default_options = {
+        'prefix': 'field-updater',      # prefix used for id and class scoping,
+        'allowDelete': False,           # delete will be allowed only if requested
+        'bodyEncode': 'form-data',      # the content encoding for POST bodies
+        'emptyDisplay': 'empty',        # the text displayed when the value is an empty string or none
+        'headers': {},                  # the set of headers sent with ajax requests
+        'inputAttributes': {            # input attributes
+            'type': 'text',
+        },
+    }
+    updater_options = dict(default_options, **options) if options else default_options
+
+    validate_options(updater_options)
 
     # random uuid to scope the DOM elements
     instance_id = uuid.uuid4()
     return {
-        'options': {
-            'instance_id': instance_id,
-            'attribute_name': attribute_name,
-            'attribute_value': attribute_value,
-            'allow_delete': allow_delete,
-            'submit_url': submit_url,
-            'if_match': if_match,
-            'if_unmodified_since': if_unmodified_since,
-            'bodyEncode': body_encode,
-            'prefix': prefix,
-            'emptyDisplay': empty_display,
-            'headersAccept': headers_accept,
+        'updater': {
+            'instanceId': instance_id,
+            'submitUrl': submit_url,
+            'attributeName': attribute_name,
+            'attributeValue': attribute_value,
+            'ifMatch': if_match,
+            'ifUnmodifiedSince': if_unmodified_since,
+            'options': updater_options,
         },
     }
+
+def validate_options(options):
+    if options['bodyEncode'] not in ['urlencoded', 'form-data']:
+        raise AttributeError('options bodyEncode must be urlencoded or form-data')
+    if options['inputAttributes']['type'] not in ['text', 'number']:
+        raise AttributeError('options inputAttributes type must be text or number')
 
 @register.filter
 def addstr(arg1, arg2):

--- a/urls.py
+++ b/urls.py
@@ -1,11 +1,11 @@
 from django.urls import path
-from .views import submit, ExampleView
+from .views import LoggingSubmitView, ExampleView
 
 urlpatterns = [
     # an example endpoint to demonstrate component use
     path('', ExampleView.as_view()),
     # a simple example submit endpoint that returns 200 ok
-    path('example_submit', submit, name='example_submit'),
+    path('example_submit', LoggingSubmitView.as_view(), name='example_submit'),
     # an example submit endpoint with a parameter that returns 200 ok
-    path('example_submit/<name>/', submit, name='example_submit'),
+    path('example_submit/<name>/', LoggingSubmitView.as_view(), name='example_submit'),
 ]

--- a/views.py
+++ b/views.py
@@ -1,18 +1,100 @@
-from django.http import HttpResponse
+import logging
+
+from django.http import HttpResponse, JsonResponse
 from django.utils.decorators import method_decorator
 from django.views.decorators.csrf import ensure_csrf_cookie
-from django.views.generic import TemplateView
+from django.views.decorators.http import condition
+from django.views.generic import View, TemplateView
+from django.views.generic.detail import SingleObjectMixin
+
+logger = logging.getLogger('django.field_updater')
 
 
 @method_decorator(ensure_csrf_cookie, name='dispatch')
 class ExampleView(TemplateView):
-    ''' An endpoint to provide exmaple use of this apps components '''
+    ''' An endpoint to provide example use of this apps components '''
     template_name = "field_updater/example.html"
 
+    def get_context_data(self, **kwargs):
+        context = super().get_context_data(**kwargs)
 
-def submit(request, *args, **kwargs):
-    ''' An example submit view that simply returns 200 OK '''
-    return HttpResponse()
+        context['updater_options_number'] = dict(
+            inputAttributes=dict(type='number'),
+        )
+        context['updater_options_delete'] = dict(
+            allowDelete=True,
+        )
+        context['updater_options_headers'] = dict(
+            headers=dict(yourHeader='yourHeaderValue'),
+        )
+        return context
 
-# TODO add more example edpoint tags to return other statuses for testing error behavior
+
+class LoggingSubmitView(View):
+    ''' An example submit view that does nothing just logs usefully '''
+    log_headers = ['Content-Type', 'Accept', 'IfMatch', 'IfUnmodifiedSince']
+
+    def post(self, request, *args, **kwargs):
+        ''' update or create your stored value '''
+        logger.info(request)
+        for key in self.log_headers:
+            if key in request.headers:
+                logger.info("{}: {}".format(key, request.headers[key]))
+        logger.info(request.POST)
+        return HttpResponse()
+
+    def delete(self, request, *args, **kwargs):
+        ''' delete your stored value '''
+        logger.info(request)
+        for key in self.log_headers:
+            if key in request.headers:
+                logger.info("{}: {}".format(key, request.headers[key]))
+        return HttpResponse()
+
+
+class ModelSubmitView(SingleObjectMixin, View):
+    ''' A simple field updater based on django SingleObjectMixin
+    get: returns json serialized model fields
+    post:
+      - view has no kwargs: creates with request POST dict
+      - view has kwargs: update/create using view kwargs to get, POST dict to update
+    delete: deletes the model instance
+    '''
+
+    def get(self, request, *args, **kwargs):
+        ''' gets the object from storage and returns JSON serialization '''
+        self.object = super().get_object()
+        data = self.object.__dict__.copy()
+        data.pop('_state')
+        return JsonResponse(data)
+
+    def post(self, request, *args, **kwargs):
+        ''' gets the object from storage and updates it '''
+        # todo break out method to allow GET params as unique identifiers
+        object_unique = kwargs
+        if len(object_unique):
+            # if we have identifying data, update/create
+            self.object, created = self.model.objects.update_or_create(
+                defaults=request.POST,
+                **object_unique
+            )
+        else:
+            # otherwise create
+            created = True
+            self.object = self.model.objects.create(**request.POST.dict())
+
+        response = HttpResponse(status=201 if created else 200)
+
+        # set a location header if created
+        if created and self.get_instance_url:
+            # TODO get_absolute_url() ?
+            response['Location'] = self.get_instance_url(self.object)
+
+        return response
+
+    def delete(self, request, *args, **kwargs):
+        ''' get and delete '''
+        self.object = super().get_object()
+        self.object.delete()
+        return HttpResponse(status=200)
 

--- a/views.py
+++ b/views.py
@@ -1,11 +1,9 @@
 import logging
 
-from django.http import HttpResponse, JsonResponse
+from django.http import HttpResponse
 from django.utils.decorators import method_decorator
 from django.views.decorators.csrf import ensure_csrf_cookie
-from django.views.decorators.http import condition
 from django.views.generic import View, TemplateView
-from django.views.generic.detail import SingleObjectMixin
 
 logger = logging.getLogger('django.field_updater')
 
@@ -50,51 +48,3 @@ class LoggingSubmitView(View):
             if key in request.headers:
                 logger.info("{}: {}".format(key, request.headers[key]))
         return HttpResponse()
-
-
-class ModelSubmitView(SingleObjectMixin, View):
-    ''' A simple field updater based on django SingleObjectMixin
-    get: returns json serialized model fields
-    post:
-      - view has no kwargs: creates with request POST dict
-      - view has kwargs: update/create using view kwargs to get, POST dict to update
-    delete: deletes the model instance
-    '''
-
-    def get(self, request, *args, **kwargs):
-        ''' gets the object from storage and returns JSON serialization '''
-        self.object = super().get_object()
-        data = self.object.__dict__.copy()
-        data.pop('_state')
-        return JsonResponse(data)
-
-    def post(self, request, *args, **kwargs):
-        ''' gets the object from storage and updates it '''
-        # todo break out method to allow GET params as unique identifiers
-        object_unique = kwargs
-        if len(object_unique):
-            # if we have identifying data, update/create
-            self.object, created = self.model.objects.update_or_create(
-                defaults=request.POST,
-                **object_unique
-            )
-        else:
-            # otherwise create
-            created = True
-            self.object = self.model.objects.create(**request.POST.dict())
-
-        response = HttpResponse(status=201 if created else 200)
-
-        # set a location header if created
-        if created and self.get_instance_url:
-            # TODO get_absolute_url() ?
-            response['Location'] = self.get_instance_url(self.object)
-
-        return response
-
-    def delete(self, request, *args, **kwargs):
-        ''' get and delete '''
-        self.object = super().get_object()
-        self.object.delete()
-        return HttpResponse(status=200)
-


### PR DESCRIPTION
fixes #17 

This is a breaking change of interface! Major version number update :)

The main point of this PR:
- Allows passing through input type='number'

Validates that the input type is either text or number ( other scenarios are not yet tested ) I do not validate any other input attributes.

Byproducts:
- allows custom headers to be passed in
- refactor to pass an options parameter through to the filed_updater tag with configuration that might well be shared between field_updater instances ( django template tags have to be on one line which makes passing a ton of attributes kind of ugly )
- refactor towards camelCase naming for future ease of use outside django
- adds more examples of use
- adds logging to the example submit endpoint for easy development