### PR TITLE
Support for browser input validation

### DIFF
--- a/static/js/fieldUpdater.js
+++ b/static/js/fieldUpdater.js
@@ -4,7 +4,7 @@ export default async function initialise(config) {
 
     // gets references to internal elements
     const displayElement = containerElement.querySelector('.' + config.options.prefix + '-display');
-    const inputsElement = containerElement.querySelector('.' + config.options.prefix + '-inputs');
+    const formElement = containerElement.querySelector('.' + config.options.prefix + '-form');
     const inputElement = containerElement.querySelector('.' + config.options.prefix + '-input');
     const submitElement = containerElement.querySelector('.' + config.options.prefix + '-submit');
     const cancelElement = containerElement.querySelector('.' + config.options.prefix + '-cancel');
@@ -34,7 +34,7 @@ export default async function initialise(config) {
     displayElement.onclick = function(e) {
         // show and update the input elements
         inputElement.value = currentValue;
-        inputsElement.hidden = false;
+        formElement.hidden = false;
         // hide the display elements
         displayElement.hidden = true;
         errorElement.hidden = true;
@@ -45,13 +45,13 @@ export default async function initialise(config) {
 
     // what happens whaen the edit cancel button is clicked
     cancelElement.onclick = function(e) {
-        inputsElement.hidden = true;
+        formElement.hidden = true;
         displayElement.hidden = false;
     };
     
     // handler to encapsulate an async submission action ( update or delete )
     function submit(action) {
-        inputsElement.hidden = true;
+        formElement.hidden = true;
         loaderElement.hidden = false;
 
         action().then(() => {
@@ -60,7 +60,7 @@ export default async function initialise(config) {
             errorElement.innerHTML = err;
             errorElement.hidden = false;
         }).finally(() => {
-            inputsElement.hidden = true;
+            formElement.hidden = true;
             displayElement.hidden = false;
             loaderElement.hidden = true;
         });
@@ -76,7 +76,10 @@ export default async function initialise(config) {
     };
 
     // what happens when the update button is clicked
-    submitElement.onclick = () => updateOrCreate(inputElement.value);
+    submitElement.onclick = (e) => {
+        e.preventDefault();
+        updateOrCreate(inputElement.value);
+    }
 
     // what happens when a key is hit in the input
     inputElement.onkeyup = function(e) {
@@ -84,15 +87,17 @@ export default async function initialise(config) {
     }
 
     async function updateOrCreate(newValue) {
-        let { ajaxUpdate } = await import("./ajaxUpdate.js");
+        if (formElement.reportValidity()) {
+            let { ajaxUpdate } = await import("./ajaxUpdate.js");
 
-        const data = {};
-        data[config.attributeName] = newValue;
+            const data = {};
+            data[config.attributeName] = newValue;
 
-        submit(() => { 
-            return storage.updateOrCreate(data).then(() => {
-                currentValue = newValue;
-            }); 
-        });
+            submit(() => {
+                return storage.updateOrCreate(data).then(() => {
+                    currentValue = newValue;
+                });
+            });
+        }
     }
 };

--- a/templates/field_updater/example.html
+++ b/templates/field_updater/example.html
@@ -1,12 +1,21 @@
 {% load field_updater_tags %}
 <html>
+    <head>
+        <style>
+        .code {
+            background-color: lightgray;
+            padding: 5px;
+            border-radius: 3px;
+        }
+        </style>
+    </head>
     <body>
         <section>
             <h1>Field Updater Examples</h1>
             <h2>simple use</h2>
             <p>
                 Provide a submit url and a single key word argument<br />
-                Click the value to show an input, edit it aand submit
+                Click the value to show an input, edit it and submit
                 A POST request will be sent to the url with body form encoded <code>key=value</code>
 
             </p>
@@ -22,7 +31,8 @@
 
             <h2>input types</h2>
             <p>
-                Provide an options dict containing <code>inputAttributes</code>a these attributes will be aplied to the input element displayed
+            Provide an options dict containing <code>inputAttributes</code> which will be set on the input element displayed</br />
+            context['updater_options_number'] = {{ updater_options_number|to_str}}
             </p>
             <div class="code">
                 {% verbatim %}
@@ -36,7 +46,8 @@
 
             <h2>allow deletion</h2>
             <p>
-                Provide an options dict containing <code>allowDelete = True</code>
+            Provide an options dict containing <code>allowDelete = True</code><br />
+            context['updater_options_delete'] = {{ updater_options_delete|to_str}}
             </p>
             <div class="code">
                 {% verbatim %}
@@ -50,7 +61,8 @@
 
             <h2>sending custom headers</h2>
             <p>
-            Provide an options dict containing <code>headers={'yourHeader':'yourHeaderValue'}</code>
+            Provide an options dict defining a headers dict<br />
+            context['updater_options_headers'] = {{ updater_options_headers|to_str}}
             </p>
             <div class="code">
                 {% verbatim %}
@@ -61,6 +73,21 @@
             </div>
             {% url 'example_submit' as submit_url %}
             {% field_updater submit_url=submit_url key='headers' options=updater_options_headers %}
+
+            <h2>Regex validation</h2>
+            <p>
+            Provide an options dict containing inputAttributes<br />
+            context['updater_options_regex'] = {{ updater_options_regex|to_str}}
+            </p>
+            <div class="code">
+                {% verbatim %}
+                {% url 'example_submit' as submit_url %}
+                <br />
+                {% field_updater submit_url=submit_url  key='headers' options=updater_options_regex %}
+                {% endverbatim %}
+            </div>
+            {% url 'example_submit' as submit_url %}
+            {% field_updater submit_url=submit_url key='headers' options=updater_options_regex %}
         </section>
     </body>
 </html>

--- a/templates/field_updater/field_updater.html
+++ b/templates/field_updater/field_updater.html
@@ -17,7 +17,7 @@ TODO: consider other input types, textarea etc...
         &#9988;
     </button>
     <span class="{{ updater.options.prefix }}-error" hidden></span>
-    <div class="{{ updater.options.prefix }}-inputs" hidden>
+    <form class="{{ updater.options.prefix }}-form" hidden>
         <input
             {% for key, value in updater.options.inputAttributes.items %} {{ key }}="{{ value }}" {% endfor %}
             class="{{ updater.options.prefix }}-input" />
@@ -28,7 +28,7 @@ TODO: consider other input types, textarea etc...
         <button type="button" class="{{ updater.options.prefix }}-cancel">
             &#10005;
         </button>
-    </div>
+    </form>
     {% comment %} 
     You can override the loader gif by providing this file in your project
     {% endcomment %}

--- a/templatetags/field_updater_tags.py
+++ b/templatetags/field_updater_tags.py
@@ -57,3 +57,8 @@ def validate_options(options):
 def addstr(arg1, arg2):
     """concatenate arg1 & arg2"""
     return str(arg1) + str(arg2)
+
+@register.filter
+def to_str(arg):
+    """ just str it for display """
+    return str(arg)

--- a/views.py
+++ b/views.py
@@ -25,6 +25,12 @@ class ExampleView(TemplateView):
         context['updater_options_headers'] = dict(
             headers=dict(yourHeader='yourHeaderValue'),
         )
+        context['updater_options_regex'] = dict(
+            inputAttributes=dict(
+                type='text',
+                pattern="[\w]{3}",
+                title='3 word characters'),
+        )
         return context
 
 


### PR DESCRIPTION
fixes #18 

Input attributes that should impose validation, now are respected, example
<img width="601" alt="Screenshot 2020-07-29 at 18 11 52" src="https://user-images.githubusercontent.com/1092029/88781684-a844ce00-d1c7-11ea-8ab9-e4b4ac1926cd.png">
