### PR TITLE
Etag fixes

### DIFF
--- a/static/js/ajaxUpdate.js
+++ b/static/js/ajaxUpdate.js
@@ -44,7 +44,7 @@ export default class AjaxUpdater {
                 ...this.options.customHeaders,
             }
             if(this.options.ifMatch) {
-                headers['If-Match'] = `"${this.options.ifMatch}"`;
+                headers['If-Match'] = this.options.ifMatch;
             }
             if(this.options.ifUnmodifiedSince) {
                 headers['If-Unmodified-Since'] = this.options.ifUnmodifiedSince;

--- a/templatetags/field_updater_tags.py
+++ b/templatetags/field_updater_tags.py
@@ -1,5 +1,6 @@
 import uuid
 from django import template
+from django.utils.http import quote_etag
 
 register = template.Library()
 
@@ -41,7 +42,7 @@ def field_updater(
             'submitUrl': submit_url,
             'attributeName': attribute_name,
             'attributeValue': attribute_value,
-            'ifMatch': if_match,
+            'ifMatch': quote_etag(if_match) if if_match else if_match,
             'ifUnmodifiedSince': if_unmodified_since,
             'options': updater_options,
         },

--- a/templatetags/field_updater_tags.py
+++ b/templatetags/field_updater_tags.py
@@ -6,8 +6,8 @@ register = template.Library()
 @register.inclusion_tag('field_updater/field_updater.html')
 def field_updater(
     submit_url,                         # url that the ajax will POST the create to
-    if_match=False,                     # If-Match header will be sent with this value, unless False
-    if_unmodified_since=False,          # If-Unmodified-Since header will be sent with this value unless False
+    if_match=None,                      # If-Match header will be sent with this value, unless False
+    if_unmodified_since=None,           # If-Unmodified-Since header will be sent with this value unless False
     options=None,               # Options for this field updater
     **kwargs):
     ''' Renders a value, on click it will render a form, on submit update that value by AJAX '''


### PR DESCRIPTION
Fixes a bug where the code would quote upon quote upon quote....
Now you can pass the ETag value in in `if_match` and it will quote it in django land if needed, then stop adding quotes!

Also defaults behaviour to start sending If-Match values and If-Unmodified-Since headers if the endpoint returns ETag and Last-Modified headers respectively, which was the intended behaviour